### PR TITLE
Support reflex-basic-host-0.2

### DIFF
--- a/nix/reflex-basic-host.json
+++ b/nix/reflex-basic-host.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/dalaing/reflex-basic-host",
-  "rev": "009354c2751fcbe3d798d756f548f2bcf767aaaa",
-  "date": "2019-05-17T13:22:29+10:00",
-  "sha256": "1ng3mfx0qa4wdw7vc9aihbkzf6cs7n7if53rg5jnxfj57h2xd3gl",
+  "url": "https://github.com/qfpl/reflex-basic-host",
+  "rev": "cb72778607ca955a8475f3073c087d2e236f1254",
+  "date": "2019-06-27T22:42:30+10:00",
+  "sha256": "0nanxmq5ys6xaqq0awfksijs457l6psyf2lxnivjj40jrl85m688",
   "fetchSubmodules": false
 }

--- a/nix/reflex-basic-host.nix
+++ b/nix/reflex-basic-host.nix
@@ -1,14 +1,13 @@
-let  
+let
   initialNixpkgs = import <nixpkgs> {};
 
   sources = rec {
     reflex-basic-host-info-pinned = initialNixpkgs.pkgs.lib.importJSON ./reflex-basic-host.json;
     reflex-basic-host = initialNixpkgs.pkgs.fetchFromGitHub {
-      owner = "dalaing";
+      owner = "qfpl";
       repo = "reflex-basic-host";
       inherit (reflex-basic-host-info-pinned) rev sha256;
     };
   };
 in
   sources.reflex-basic-host
-

--- a/nix/reflex-platform.json
+++ b/nix/reflex-platform.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/reflex-frp/reflex-platform",
-  "rev": "beaa34d244176fc2ff8f70642812141eaf3e559b",
-  "date": "2019-05-16T11:37:55-04:00",
-  "sha256": "1sfibav817qpvw8j4fm1jx4m2dvb3a5ra8j2ff6hc8w18i9j0ig4",
+  "rev": "716879f16d53c93766e7ed9af17416fccb2edfe1",
+  "date": "2019-06-15T14:12:13-04:00",
+  "sha256": "1mngxa24cfpvxxq4hgh77nw36vny4abl5wi2xmlwpkk25wzm0h0x",
   "fetchSubmodules": false
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -2,4 +2,4 @@
 #! nix-shell -i bash -p nix-prefetch-git
 
 nix-prefetch-git https://github.com/reflex-frp/reflex-platform > reflex-platform.json
-nix-prefetch-git https://github.com/dalaing/reflex-basic-host > reflex-basic-host.json
+nix-prefetch-git https://github.com/qfpl/reflex-basic-host > reflex-basic-host.json

--- a/reflex-brick.cabal
+++ b/reflex-brick.cabal
@@ -27,9 +27,9 @@ library
   build-depends:       base              >=4.9 && <4.13
                      , brick             >= 0.37 && < 0.47
                      , bytestring        >= 0.10 && < 0.11
-                     , dependent-map     >= 0.2.4 && < 0.3
-                     , dependent-sum     >= 0.4 && < 0.5
-                     , dependent-sum-template >= 0.0 && < 0.1
+                     , dependent-map     >= 0.2.4 && < 0.4
+                     , dependent-sum     >= 0.4 && < 0.7
+                     , dependent-sum-template >= 0.0 && < 0.2
                      , lens              >= 4.16 && < 4.18
                      , mtl               >= 2.2 && < 2.3
                      , reflex            >= 0.5 && < 0.7

--- a/reflex-brick.cabal
+++ b/reflex-brick.cabal
@@ -33,7 +33,7 @@ library
                      , lens              >= 4.16 && < 4.18
                      , mtl               >= 2.2 && < 2.3
                      , reflex            >= 0.5 && < 0.7
-                     , reflex-basic-host >= 0.1 && < 0.2
+                     , reflex-basic-host >= 0.2 && < 0.3
                      , stm               >= 2.4 && < 2.6
                      , vty               >= 5.21 && < 5.26
   ghc-options:         -Wall

--- a/src/Reflex/Brick.hs
+++ b/src/Reflex/Brick.hs
@@ -125,4 +125,4 @@ runReflexBrickApp initial fn = do
     performEvent_ $
       liftIO . writeBChan bChan . Left . RBSuspendAndResume <$> rbaSuspendAndResume rba
 
-    pure ((), eQuit)
+    pure eQuit


### PR DESCRIPTION
Do not merge until after qfpl/reflex-basic-host#7 is merged. Needs an update of reflex-basic-host.json also.